### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/android-x86/external/webkit/WebCore/platform/chromium/PopupMenuChromium.cpp
+++ b/android-x86/external/webkit/WebCore/platform/chromium/PopupMenuChromium.cpp
@@ -130,7 +130,7 @@ public:
     void setTextOnIndexChange(bool value) { m_setTextOnIndexChange = value; }
 
     // Sets whether we should accept the selected index when the popup is
-    // abandonned.
+    // abandoned.
     void setAcceptOnAbandon(bool value) { m_shouldAcceptOnAbandon = value; }
 
     // Sets whether pressing the down/up arrow when the last/first row is


### PR DESCRIPTION

    Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
    should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

    If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
    at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
    I’m aware of it.

    Looking for the source code of this bot? Well, you have to be patient! The bot is under development
    and I will publish the source code as soon as I’m finished with it.

    With kind regards,
    TheTypoMaster
                